### PR TITLE
Download Mode for libraries, JSON, jar files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+target/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-.idea/
-target/

--- a/pom.xml
+++ b/pom.xml
@@ -33,5 +33,15 @@
 	    <artifactId>srgutils</artifactId>
 	    <version>0.4.9</version>
 	</dependency>
+	<dependency>
+    	    <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10</version>
+        </dependency>
+	<dependency>
+    	    <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
+	</dependency>
   </dependencies>
 </project>

--- a/src/com/thistestuser/mcpfixer/FileDownloader.java
+++ b/src/com/thistestuser/mcpfixer/FileDownloader.java
@@ -1,0 +1,271 @@
+package com.thistestuser.mcpfixer;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.apache.commons.io.FileUtils;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+public class FileDownloader
+{
+        private final String version;
+        private final File mcpFolder;
+
+        public FileDownloader(String version, File mcpFolder)
+        {
+                this.version = version;
+                this.mcpFolder = mcpFolder;
+        }
+
+        public int run() throws IOException
+        {
+                System.out.println("Downloading version manifest");
+                URL manifestURL = new URL("https://piston-meta.mojang.com/mc/game/version_manifest_v2.json");
+                File manifest = new File(mcpFolder, "jars\\version_manifest_v2.json");
+
+                FileUtils.copyURLToFile(manifestURL, manifest);
+
+                if (manifest.exists())
+                {
+                        downloadJson(manifest, version, mcpFolder);
+                }
+                System.out.println("Done");
+                return 0;
+        }
+
+        public JsonObject getJsonAsObject(File json) throws IOException
+        {
+                JsonObject object;
+                Reader reader = Files.newBufferedReader(json.toPath());
+                JsonElement element = JsonParser.parseReader(reader);
+                object = element.getAsJsonObject();
+                return object;
+        }
+
+        public void downloadJson(File manifest, String version, File mcpFolder) throws IOException
+        {
+                JsonObject manifestObject = getJsonAsObject(manifest);
+                JsonArray versions = manifestObject.getAsJsonArray("versions");
+                System.out.println("Downloading version JSON");
+                for (int i = 0; i < versions.size(); i++)
+                {
+                        JsonElement id = versions.get(i).getAsJsonObject().get("id");
+
+                        if (id.getAsString().contains(version))
+                        {
+                                URL url = new URL(versions.get(i).getAsJsonObject().get("url").getAsString());
+                                File versionJson = new File(mcpFolder, "jars\\versions\\" + version + "/" + version + ".json");
+                                FileUtils.copyURLToFile(url, versionJson);
+
+                                downloadSide(versionJson, mcpFolder, "client", version);
+                                downloadSide(versionJson, mcpFolder, "server", version);
+                                parseJson(version, versionJson, mcpFolder);
+
+                                System.out.println("Deleting version manifest");
+                                FileUtils.deleteQuietly(manifest);
+                                break;
+                        }
+                }
+        }
+
+        public void downloadSide(File json, File mcpFolder, String side, String version) throws IOException
+        {
+                JsonObject versionObject = getJsonAsObject(json);
+                JsonObject downloads = versionObject.getAsJsonObject("downloads");
+                JsonObject sideObject = downloads.getAsJsonObject(side);
+                URL url = new URL(sideObject.get("url").getAsString());
+
+                System.out.println("Downloading " + side);
+
+                switch (side)
+                {
+                        case "client":
+                                File clientJar = new File(mcpFolder, "jars\\versions\\" + version + File.separator + version + ".jar");
+                                FileUtils.copyURLToFile(url, clientJar);
+                        case "server":
+                                File serverJar = new File(mcpFolder, "jars\\minecraft_server." + version + ".jar");
+                                FileUtils.copyURLToFile(url, serverJar);
+                }
+        }
+
+        public void parseJson(String version, File json, File mcpFolder) throws IOException
+        {
+                JsonObject versionObject = getJsonAsObject(json);
+                JsonArray libraries = versionObject.getAsJsonArray("libraries");
+
+                for (int i = 0; i < libraries.size(); i++)
+                {
+                        JsonObject entry = libraries.get(i).getAsJsonObject();
+                        JsonObject downloads = entry.getAsJsonObject("downloads");
+
+                        if (entry.has("rules"))
+                        {
+                                JsonArray rules = entry.getAsJsonArray("rules");
+
+                                if (isAllowed(rules))
+                                {
+                                        downloadLibrary(downloads, mcpFolder);
+                                        if (downloads.has("classifiers"))
+                                        {
+                                                downloadNative(version, downloads.getAsJsonObject("classifiers"), mcpFolder);
+                                        }
+                                }
+                                continue;
+                        }
+
+                        if (downloads.has("classifiers"))
+                        {
+                                downloadNative(version, downloads.getAsJsonObject("classifiers"), mcpFolder);
+                                continue;
+                        }
+                        downloadLibrary(downloads, mcpFolder);
+                }
+        }
+
+        public boolean isAllowed(JsonArray rules)
+        {
+                String os = OS.getOS().name;
+
+                for (int i = 0; i < rules.size(); i++)
+                {
+                        JsonObject ruleEntry = rules.get(i).getAsJsonObject();
+                        JsonElement action = ruleEntry.get("action");
+
+                        JsonObject osRule = ruleEntry.getAsJsonObject("os");
+
+                        if (Objects.equals(action.getAsString(), "disallow"))
+                        {
+                                if (ruleEntry.has("os"))
+                                {
+                                        JsonElement name = osRule.get("name");
+                                        if (Objects.equals(name.getAsString(), os) || (name.getAsString().contains("osx") && os.contains("mac")))
+                                                return false;
+                                        else return true;
+                                }
+                                else continue;
+                        }
+
+                        if (Objects.equals(action.getAsString(), "allow"))
+                        {
+                                if (ruleEntry.has("os"))
+                                {
+                                        JsonElement name = osRule.get("name");
+                                        if (Objects.equals(name.getAsString(), os) || (name.getAsString().contains("osx") && os.contains("mac")))
+                                                return true;
+                                }
+                        }
+                }
+                return false;
+        }
+
+        public void downloadLibrary(JsonObject downloads, File mcpFolder) throws IOException
+        {
+                String path = downloads.getAsJsonObject("artifact").get("path").getAsString();
+                System.out.println("Downloading library " + path.substring(path.lastIndexOf('/') + 1));
+
+                File file = new File(mcpFolder, "jars\\libraries\\" + path);
+                URL url = new URL(downloads.getAsJsonObject("artifact").get("url").getAsString());
+                FileUtils.copyURLToFile(url, file);
+        }
+
+        // < 1.19
+        public void downloadNative(String version, JsonObject classifiers, File mcpFolder) throws IOException
+        {
+                String os = OS.getOS().name;
+
+                if (classifiers.has("natives-" + os))
+                {
+                        String path = classifiers.getAsJsonObject("natives-" + os).get("path").getAsString();
+                        String url = classifiers.getAsJsonObject("natives-" + os).get("url").getAsString();
+
+                        System.out.println("Downloading native " + path.substring(path.lastIndexOf('/') + 1));
+
+                        File nativeFile = new File(mcpFolder, "jars\\libraries\\" + path);
+                        FileUtils.copyURLToFile(new URL(url), nativeFile);
+
+                        System.out.println("Extracting native " + path.substring(path.lastIndexOf('/') + 1));
+
+                        extractNative(version, nativeFile, mcpFolder);
+                }
+        }
+
+        // < 1.19
+        public void extractNative(String version, File nativeFile, File mcpFolder) throws IOException
+        {
+                File nativesDir = new File(mcpFolder + File.separator + "jars\\versions\\" + version + File.separator + version + "-natives" + File.separator);
+
+                if (!nativesDir.exists())
+                {
+                        FileUtils.forceMkdir(nativesDir);
+                }
+
+                ZipInputStream inputStream = new ZipInputStream(Files.newInputStream(Paths.get(nativeFile.getAbsolutePath())));
+                ZipEntry entry = inputStream.getNextEntry();
+
+                while (entry != null)
+                {
+                        String output = nativesDir.getAbsolutePath() + File.separator + entry.getName();
+                        String[] excluded = new String[] { "md5", "sha1", "git" };
+
+                        if (!entry.isDirectory() && Arrays.stream(excluded).noneMatch(entry.getName()::endsWith))
+                        {
+                                BufferedOutputStream outputStream = new BufferedOutputStream(Files.newOutputStream(Paths.get(output)));
+                                byte[] b = new byte[4096];
+                                int len;
+                                while ((len = inputStream.read(b)) > 0)
+                                {
+                                        outputStream.write(b, 0, len);
+                                }
+                                outputStream.close();
+                        }
+                        else if (entry.isDirectory())
+                        {
+                                File subdir = new File(output);
+                                FileUtils.forceMkdir(subdir);
+                        }
+                        inputStream.closeEntry();
+                        entry = inputStream.getNextEntry();
+                }
+                inputStream.close();
+        }
+
+        // I ripped this enum from the ForgeGradle class VersionJson (with modification). Kudos to them.
+        public enum OS
+        {
+                WINDOWS("windows"), MACOS("macos"), LINUX("linux"), UNKNOWN("unknown");
+
+                private final String name;
+
+                OS(String name)
+                {
+                        this.name = name;
+                }
+
+                public static OS getOS()
+                {
+                        String property = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
+
+                        for (OS os : OS.values())
+                        {
+                                if (property.contains(os.name))
+                                {
+                                        return os;
+                                }
+                        }
+                        return UNKNOWN;
+                }
+        }
+}

--- a/src/com/thistestuser/mcpfixer/FileDownloader.java
+++ b/src/com/thistestuser/mcpfixer/FileDownloader.java
@@ -64,7 +64,7 @@ public class FileDownloader
                 {
                         JsonElement id = versions.get(i).getAsJsonObject().get("id");
 
-                        if (id.getAsString().contains(version))
+                        if (id.getAsString().equals(version))
                         {
                                 URL url = new URL(versions.get(i).getAsJsonObject().get("url").getAsString());
                                 File versionJson = new File(mcpFolder, "jars\\versions\\" + version + "/" + version + ".json");

--- a/src/com/thistestuser/mcpfixer/Main.java
+++ b/src/com/thistestuser/mcpfixer/Main.java
@@ -1,6 +1,7 @@
 package com.thistestuser.mcpfixer;
 
 import java.io.File;
+import java.io.IOException;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -10,20 +11,21 @@ import org.apache.commons.cli.ParseException;
 
 public class Main
 {
-    public static void main(String[] args)
+    public static void main(String[] args) throws IOException
     {
         System.exit(run(args));
     }
     
-	public static int run(String[] args)
+	public static int run(String[] args) throws IOException
 	{
 		Options options = new Options();
 		options.addOption("i", "input", true,
 			"The input where files will be read (patch mode only)");
 		options.addOption("o", "output", true, "The output to place files (patch mode only)");
 		options.addOption("c", "conf", true, "The config folder in your mcp workspace (csv mode only)");
-		options.addOption("w", "mcp", true, "The directory of your mcp workspace (libraries mode only)");
-		options.addOption("m", "mode", true, "Either \"patch\", \"csv\", or \"libraries\"");
+		options.addOption("w", "mcp", true, "The directory of your mcp workspace (libraries and download mode only)");
+		options.addOption("v", "version", true, "The minecraft version of your mcp workspace (download mode only)");
+		options.addOption("m", "mode", true, "Either \"patch\", \"csv\", \"libraries\", or \"download\"");
 		
 		CommandLineParser cmdlineParser = new DefaultParser();
 		CommandLine cmdLine;
@@ -111,6 +113,28 @@ public class Main
 				return 3;
 			}
 			return new ClasspathGenerator(mcpFolder).run();
+		}
+		if(mode.equalsIgnoreCase("download")) {
+			if(!cmdLine.hasOption("mcp"))
+			{
+				System.out.println("No mcp folder specified");
+				return 3;
+			}
+			if(!cmdLine.hasOption("version"))
+			{
+				System.out.println("Minecraft version not specified");
+				return 3;
+			}
+
+			String mcp = cmdLine.getOptionValue("mcp");
+			String version = cmdLine.getOptionValue("version");
+			File mcpFolder = new File(mcp);
+			if(!mcpFolder.exists())
+			{
+				System.out.println("Invaild mcp location");
+				return 3;
+			}
+			return new FileDownloader(version, mcpFolder).run();
 		}
 		System.out.println("Invalid mode (patch, csv, or libraries) specified");
 		return 2;


### PR DESCRIPTION
This pull request adds a new Download mode to the MCPFixer command line.

This mode allows the end-user to automatically download (most of) the non-config files needed for executing decompile.bat. It downloads the version manifest (which gets deleted at the end), the version JSON, both client and server jars, and the libraries and natives. The natives also get extracted. The program is built around the MCP 9.40 folder structure and file name expectations. It uses GSON for JSON parsing and Commons-IO for file downloading.

Usage:

```
java -jar fixer.jar --version {MC_VERSION} --mcp {MCP_DIR} --mode download
```

Specific example: 

```
java -jar fixer.jar --version 1.13.2 --mcp D:\MCP\mcp940 --mode download
```

At the moment, the end-user will still need to launch Minecraft at least once, since this mode does not currently download the assets (although that can definitely be an option in the future). 

This mode is intended to remove the need to drag and drop the libraries from MCPConfig, as well as the need to manually download the required game files into the workspace. MCP does do this for you, albeit it only works after the game has been launched once (and it only does it for the client). If asset downloading gets added, this mode will allow the user to set up all the game files and libraries easily and without extra steps/tools beyond MCPFixer.

There is one issue I’ve found with this, although it actually has to do more with how MCP 9.40 works. For Mojang-made libraries (anything with com.mojang as well as icuj4-core-mojang in older MC versions), MCP seems to not recognize the library versions listed in the JSON file, and instead pulls some other versions from your .minecraft. I’m not sure why this is, but it’s likely due to some quirk in the MCP script files. This shouldn’t interfere with the decompilation process, but it may interfere with the classpath generator, so it should be looked at. 
